### PR TITLE
fix gcc build failed

### DIFF
--- a/fetch
+++ b/fetch
@@ -13,3 +13,7 @@ sha256sum -c 'sha256sums.txt'
 
 tar -xf "$SRC/binutils-2.37.tar.xz" -C "$SRC"
 tar -xf "$SRC/gcc-11.2.0.tar.xz"    -C "$SRC"
+
+# First download GCC prequistes...
+cd $SRC/gcc-11.2.0/
+./contrib/download_prerequisites


### PR DESCRIPTION
GCC Build failed because it's prerequisites: libgmp, libmpc, libmpfr are missing
![Screenshot from 2022-02-09 11-30-54](https://user-images.githubusercontent.com/95996311/153138005-b0eb9bea-0b03-48cf-9aad-966e34e61a73.png)